### PR TITLE
Add language detector unit tests

### DIFF
--- a/tests/test_language_detector.py
+++ b/tests/test_language_detector.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ml.multilingual.language_detector import LanguageDetector
+
+
+def test_english_detection_with_ngrams():
+    text = "This is a simple English sentence used for testing the detection mechanism."
+    detector = LanguageDetector()
+    result = detector.detect_language(text)
+    assert result['language'] == 'en'
+    assert result['confidence'] > 0
+    assert result['method'] == 'ngram'
+
+
+def test_insufficient_text():
+    detector = LanguageDetector()
+    result = detector.detect_language("Hi")
+    assert result['language'] == 'unknown'
+    assert result['method'] == 'insufficient_text'


### PR DESCRIPTION
## Summary
- add test cases for the fallback n-gram method
- ensure short text returns an insufficient text result
- include empty `__init__.py` so pytest can discover tests

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*